### PR TITLE
Dev

### DIFF
--- a/gxm/__init__.py
+++ b/gxm/__init__.py
@@ -1,5 +1,5 @@
 from gxm.core import Environment, EnvironmentState, Timestep, Trajectory, Transition
-from gxm.registration import make
+from gxm.registration import make, register
 
 __all__ = [
     "Environment",
@@ -8,4 +8,5 @@ __all__ = [
     "Transition",
     "Trajectory",
     "make",
+    "register",
 ]

--- a/gxm/registration.py
+++ b/gxm/registration.py
@@ -10,6 +10,29 @@ from gxm.environments import (
     XMiniGridEnvironment,
 )
 
+_registry = {
+    "Gymnax": GymnaxEnvironment,
+    "Pgx": PgxEnvironment,
+    "Envpool": EnvpoolEnvironment,
+    "Craftax": CraftaxEnvironment,
+    "XMiniGrid": XMiniGridEnvironment,
+    "JAXAtari": JAXAtariEnvironment,
+    "Gymnasium": GymnasiumEnvironment,
+    "Navix": NavixEnvironment,
+    "Brax": BraxEnvironment,
+}
+
+
+def register(library: str, environment_class):
+    """
+    Register a new environment library.
+
+    Args:
+        library (str): The name of the library to register.
+        environment_class: The environment class to associate with the library.
+    """
+    _registry[library] = environment_class
+
 
 def make(id: str, **kwargs):
     """
@@ -30,15 +53,8 @@ def make(id: str, **kwargs):
         >>> env = make("Envpool/Pong-v5")
     """
     library = id.split("/", 1)[0]
-    Environment = {
-        "Gymnax": GymnaxEnvironment,
-        "Pgx": PgxEnvironment,
-        "Envpool": EnvpoolEnvironment,
-        "Craftax": CraftaxEnvironment,
-        "XMiniGrid": XMiniGridEnvironment,
-        "JAXAtari": JAXAtariEnvironment,
-        "Gymnasium": GymnasiumEnvironment,
-        "Navix": NavixEnvironment,
-        "Brax": BraxEnvironment,
-    }[library]
+    if library not in _registry:
+        raise ValueError(f"Unknown environment library: {library}")
+    Environment = _registry[library]
     return Environment(id, **kwargs)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gxm"
-version = "0.1.1"
+version = "0.1.2"
 description = "Reinforcement Learning Environemts in JAX."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/environments/test_gymnasium.py
+++ b/tests/environments/test_gymnasium.py
@@ -16,6 +16,7 @@ class TestGymnasium(TestEnvironment):
             "CartPole-v1",
             "MountainCar-v0",
             "Acrobot-v1",
+            "MountainCarContinuous-v0",
         ]
     )
     def env(self, request):


### PR DESCRIPTION
This pull request introduces improvements to the environment registration and instantiation system, enhances compatibility handling in the Gymnasium environment wrapper, and expands test coverage. The main changes include making the environment registry extensible via a new `register` function, updating the `make` function to use this registry, and adding robustness to Gymnasium environment resets and steps to handle varying info structures.

**Environment registration and extensibility:**

* Added a global `_registry` dictionary in `gxm/registration.py` to store environment libraries and their associated classes, and introduced a `register` function to allow dynamic registration of new environment libraries. (`[gxm/registration.pyR13-R35](diffhunk://#diff-5c7c8d2b2258d879cf5292bb4ac7357139391c1438593d3ee83dfc7c52e4c9a2R13-R35)`)
* Updated the `make` function in `gxm/registration.py` to use the new `_registry` for environment lookup, raising a clear error if an unknown library is requested. (`[gxm/registration.pyL33-R60](diffhunk://#diff-5c7c8d2b2258d879cf5292bb4ac7357139391c1438593d3ee83dfc7c52e4c9a2L33-R60)`)
* Exposed the new `register` function in the package API via `gxm/__init__.py`. (`[[1]](diffhunk://#diff-97cfd8818af97c99e8564b62d7e389a587460f0bdf2e3c30e44f0c5babedd3f6L2-R2)`, `[[2]](diffhunk://#diff-97cfd8818af97c99e8564b62d7e389a587460f0bdf2e3c30e44f0c5babedd3f6R11)`)

**Gymnasium environment compatibility and robustness:**

* Improved the handling of the `info` structure in `gxm/environments/gymnasium_environment.py` by comparing tree structures after reset and step, and filling with zeros if mismatches are detected, ensuring compatibility across various Gymnasium environments. (`[[1]](diffhunk://#diff-bf3fcef9ef424794e9fc11664ba08d25bf31e79c08f9ddf453f82bf1ff2273ccL35-R41)`, `[[2]](diffhunk://#diff-bf3fcef9ef424794e9fc11664ba08d25bf31e79c08f9ddf453f82bf1ff2273ccR70-R76)`, `[[3]](diffhunk://#diff-bf3fcef9ef424794e9fc11664ba08d25bf31e79c08f9ddf453f82bf1ff2273ccR107-R115)`)
* Updated action reshaping logic in Gymnasium environment callbacks to use `jax.tree.map`, improving flexibility for batched and structured actions. (`[gxm/environments/gymnasium_environment.pyL125-R146](diffhunk://#diff-bf3fcef9ef424794e9fc11664ba08d25bf31e79c08f9ddf453f82bf1ff2273ccL125-R146)`)

**Testing improvements:**

* Added `MountainCarContinuous-v0` to the list of tested environments in `tests/environments/test_gymnasium.py` to increase test coverage. (`[tests/environments/test_gymnasium.pyR19](diffhunk://#diff-1ae629f56d7d66fb4e06c179e6ca703010b9e266842c3785fd8d9524f709f8fbR19)`)